### PR TITLE
Major Simplification of logs

### DIFF
--- a/include/log.hpp
+++ b/include/log.hpp
@@ -7,31 +7,28 @@
 struct Log
 {
     std::vector<Transaction> data;
-    uint32_t end = 0;
     void AddTrans(Transaction &&v)
-    {
-        end += (end < max_log_size); //branchless
-        if (data.size() == end && end < max_log_size) //if memory reserved is full and max isnt reached
+    {                                                                     //branchless
+        if (data.capacity() == data.size() && data.size() < max_log_size) //if memory reserved is full and max isnt reached
         {
             if (data.size() + pre_log_size > max_log_size) //if prefetched memory is larger then max
             {
-                data.resize(max_log_size); //just allocate max
+                //std::cout << "allocating " << max_log_size << '\n';
+                data.reserve(max_log_size); //just allocate max
             }
             else
             {
-                data.resize(data.size() + pre_log_size); //prefetching memory
+                //std::cout << "allocating " << data.size() + pre_log_size << '\n';
+                data.reserve(data.size() + pre_log_size); //prefetching memory
             }
         }
-        for (uint32_t i = end - 1; i > 0; --i) //size: 10, 9-1, all moved to the right one
-        {
-            data[i] = std::move(data[i - 1]);
-        }
-        data[0] = std::move(v); //override first
+        data.push_back(v);
+        //std::cout << "size is " << data.size() << '\n';
     }
     Json::Value Serialize() const
     {
         Json::Value res;
-        for (uint32_t i = 0; i < end; ++i)
+        for (uint32_t i = 0; i < data.size(); ++i)
         {
             res[i]["to"] = data[i].to;
             res[i]["from"] = data[i].from;

--- a/include/user.hpp
+++ b/include/user.hpp
@@ -37,17 +37,17 @@ struct User
         {
             if (max_log_size > (log_j.size() + pre_log_size)) //if current imported log's size + prefetch amount is less then max
             {
-                log.data.resize(log_j.size() + pre_log_size); //allocate that amount
-                log.end = log_j.size();
+                //std::cout << "allocating " << log_j.size() + pre_log_size << '\n';
+                log.data.reserve(log_j.size() + pre_log_size); //allocate that amount
             }
             else
             {
-                log.data.resize(max_log_size); //allocate max amount
-                log.end = max_log_size;
+                //std::cout << "allocating " << max_log_size << '\n';
+                log.data.reserve(max_log_size); //allocate max amount
             }
-            for (uint32_t i = 0; i < log.end; ++i)
+            for (uint32_t i = 0; i < log_j.size(); ++i)
             {
-                log.data[i] = std::move(Transaction(log_j[i]["from"].asCString(), log_j[i]["to"].asCString(), log_j[i]["amount"].asUInt(), log_j[i]["time"].asUInt64()));
+                log.data.push_back(std::move(Transaction(log_j[i]["from"].asCString(), log_j[i]["to"].asCString(), log_j[i]["amount"].asUInt(), log_j[i]["time"].asUInt64())));
             }
         }
     }


### PR DESCRIPTION
by replacing `end` with `size` calls
and replacing `size` calls with `capacity` calls
and replacing `resize` calls with `reserve`

it allows for 
* the removing of `end` and multiple conditionals
* reserve() is probably better optimized for this
* far more readable